### PR TITLE
Add update-all.sh script to rebuild only out of date packages

### DIFF
--- a/cook.sh
+++ b/cook.sh
@@ -223,6 +223,7 @@ then
         done
     else
         echo "cook.sh: recipe '$1' not found" >&2
+        exit 1
     fi
 else
     usage "{package}"

--- a/cook.sh
+++ b/cook.sh
@@ -101,6 +101,14 @@ function op {
             fi
             popd > /dev/null
             ;;
+        gitversion)
+            if [ -d build/.git ]
+            then
+                echo "$(op $1 version)-$(git -C build rev-parse --short HEAD)"
+            else
+                op $1 version
+            fi
+            ;;
         update)
             pushd build > /dev/null
             skip="0"

--- a/update-all.sh
+++ b/update-all.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+for recipe in `ls -1 recipes`
+do
+    if [ ! -f "recipes/$recipe/stage.tar" ]
+    then
+        echo "$recipe: building..."
+        ./cook.sh $recipe dist
+    else
+        oldver=$(./cook.sh $recipe gitversion)
+        ./cook.sh $recipe update
+        newver=$(./cook.sh $recipe gitversion)
+        if [ "$oldver" = "$newver" ]
+        then
+            echo "$recipe: up to date (version $newver)."
+        else
+            echo "$recipe: updating $oldver -> $newver..."
+    	    ./cook.sh $recipe dist
+        fi
+    fi
+done

--- a/update-packages.sh
+++ b/update-packages.sh
@@ -2,7 +2,14 @@
 
 set -e
 
-for recipe in `ls -1 recipes`
+if [ $# = 0 ]
+then
+    recipes=$(ls -1 recipes)
+else
+    recipes=$@
+fi
+
+for recipe in $recipes
 do
     if [ ! -f "recipes/$recipe/stage.tar" ]
     then


### PR DESCRIPTION
Something like this is necessary in order for the cookbook to replace the Makefiles in the `redox` repo.