### PR TITLE
Do not copy .cargo and libc-artifacts

### DIFF
--- a/cook.sh
+++ b/cook.sh
@@ -135,7 +135,7 @@ function op {
             fi
             if [ "$skip" -eq "0" ]
             then
-                cp -r "$ROOT/Xargo.toml" "$ROOT/.cargo" "$ROOT/libc-artifacts" .
+                cp -r "$ROOT/Xargo.toml" .
                 xargo build --target "$TARGET" --release $CARGOFLAGS
             fi
             popd > /dev/null
@@ -149,7 +149,7 @@ function op {
             fi
             if [ "$skip" -eq "0" ]
             then
-                cp -r "$ROOT/Xargo.toml" "$ROOT/.cargo" "$ROOT/libc-artifacts" .
+                cp -r "$ROOT/Xargo.toml" .
                 xargo test --no-run --target "$TARGET" --release $CARGOFLAGS
             fi
             popd > /dev/null


### PR DESCRIPTION
Cargo searches parent directories for .cargo, so this is unnecessary.