### PR TITLE
Make stage call unstage

### DIFF
--- a/cook.sh
+++ b/cook.sh
@@ -168,6 +168,7 @@ function op {
             popd > /dev/null
             ;;
         stage)
+            op $1 unstage
             mkdir -p stage
             pushd build > /dev/null
             skip=0


### PR DESCRIPTION
We don't want the package to potentially have artifacts from a prior
build.