### PR TITLE
Handle patches in prepare

### DIFF
--- a/cook.sh
+++ b/cook.sh
@@ -88,6 +88,11 @@ function op {
         prepare)
             rm -rf build
             cp -r source build
+
+            for patch in *.patch
+            do
+                patch -p1 -d build < "$patch"
+            done
             ;;
         unprepare)
             rm -rf build

--- a/recipes/gnu-make/recipe.sh
+++ b/recipes/gnu-make/recipe.sh
@@ -26,7 +26,6 @@ function recipe_update {
 }
 
 function recipe_build {
-    patch -p1 < ../make.patch
     ./configure --host=${HOST} --prefix=/ CFLAGS=-DPOSIX --without-guile
     make
     return 1


### PR DESCRIPTION
This is the same loop I originally added in #4, but moved to prepare. It could instead be handled by the recipe, but I think this is generally useful enough to handle in `cook.sh`.

Fixes #14.