### PR TITLE
Avoid use of GNU specific find argument

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -23,8 +23,8 @@ do
         echo -e "\033[01;38;5;155mrepo - preparing $recipe\033[0m" >&2
         ./cook.sh "$recipe" prepare
     else
-        TIME_SOURCE="$(find recipes/$recipe/source -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
-        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
+        TIME_SOURCE="$(find recipes/$recipe/source -type f -not -path '*/.git*' -exec stat -f "%Sm" -t "%s" {} + | sort -nr | head -n 1)"
+        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -exec stat -f "%Sm" -t "%s" {} + | sort -nr | head -n 1)"
         if [ "$TIME_SOURCE" -gt "$TIME_BUILD" ]
         then
             echo -e "\033[01;38;5;155mrepo - repreparing $recipe\033[0m" >&2
@@ -37,7 +37,7 @@ do
         echo -e "\033[01;38;5;155mrepo - building $recipe\033[0m" >&2
         ./cook.sh "$recipe" update build stage tar
     else
-        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
+        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -exec stat -f "%Sm" -t "%s" {} + | sort -nr | head -n 1)"
         TIME_STAGE="$(stat -c "%Y" recipes/$recipe/stage.tar)"
         if [ "$TIME_BUILD" -gt "$TIME_STAGE" ]
         then


### PR DESCRIPTION
This changes the repo script to use a BSD/GNU compatible `find` invocation. Can't test it too comprehensively but it seems to work on BSD find from Mac OS X, and GNU find.

Only a "tentative" fix because my internet is absolutely atrocious right now, and I just can't seem to finish downloading and running Redox... here's a small test showing that the two commands do the same, though (using `gfind` for GNU).

    $ ls -lah
    total 8
    drwxr-xr-x   4 msikma  staff   136B Jun 11 22:26 .
    drwxr-xr-x@ 93 msikma  staff   3.1K Jun 11 22:19 ..
    -rw-r--r--   1 msikma  staff     0B Jun 11 22:25 asdf
    -rwxr-xr-x   1 msikma  staff   3.6K Apr  4 11:05 setup.py
    $ find . -exec stat -f "%Sm" -t "%s" {} +
    1497187571
    1497187540
    1491271529
    $ find . -exec stat -f "%Sm" -t "%s" {} +
    1497187571
    1497187540
    1491271529
    $ gfind . -exec stat -f "%Sm" -t "%s" {} +
    1497187571
    1497187540
    1491271529
    $ gfind . -printf "%Ts\n" # original command, doesn't work on BSD
    1497187571
    1497187540
    1491271529
