### PR TITLE
Set $XARGO_HOME to build std et al only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ stage
 stage.sig
 stage.tar
 stage.toml
+xargo-home

--- a/config.sh
+++ b/config.sh
@@ -8,3 +8,4 @@ export TARGET=x86_64-unknown-redox
 ROOT="$(cd `dirname "$0"` && pwd)"
 REPO="$ROOT/repo/$TARGET"
 export CC="$ROOT/libc-artifacts/gcc.sh"
+export XARGO_HOME="$ROOT/xargo-home"


### PR DESCRIPTION
I don't know what logic (if any) we need to add to handle updates to Rust