### PR TITLE
Add rustual-boy recipe

### DIFF
--- a/recipes/rustual-boy/recipe.sh
+++ b/recipes/rustual-boy/recipe.sh
@@ -1,0 +1,14 @@
+GIT=https://github.com/xtibor/rustual-boy.git
+BRANCH=redox
+
+function recipe_update {
+    cd rustual-boy-cli
+}
+
+function recipe_build {
+    cd rustual-boy-cli
+}
+
+function recipe_stage {
+    mv rustual-boy-cli/target target
+}


### PR DESCRIPTION
This pull request adds a recipe for [Rustual Boy](https://github.com/emu-rs/rustual-boy), a Virtual Boy video game emulator. Some minimal changes had to be made to get it compile and run: I updated some dependencies and added a temporary null audio driver.

[Screenshot](https://user-images.githubusercontent.com/1627292/27997060-6c23aa3c-64f0-11e7-9b57-f74d9f3b450b.png)
