### PR TITLE
Detecting find and stat from Homebrew/MacPorts on macOS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -9,3 +9,22 @@ ROOT="$(cd `dirname "$0"` && pwd)"
 REPO="$ROOT/repo/$TARGET"
 export CC="x86_64-elf-redox-gcc"
 export XARGO_HOME="$ROOT/xargo"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # GNU find
+    FIND="gfind";
+
+    # GNU stat from Homebrew or MacPorts
+    if [ ! -z "$(which brew)" ]; then
+        STAT="$(brew --prefix)/opt/coreutils/libexec/gnubin/stat";
+    elif [ ! -z "$(which port)" ]; then
+        # TODO: find a programatic way of asking MacPorts for it's root dir.
+        STAT="/opt/local/opt/coreutils/libexec/gnubin/stat";
+    else
+        echo "Please install either Homebrew or MacPorts and run the boostrap script."
+        exit 1
+    fi
+else
+    FIND="find"
+    STAT="stat";
+fi

--- a/repo.sh
+++ b/repo.sh
@@ -24,8 +24,8 @@ do
         echo -e "\033[01;38;5;155mrepo - preparing $recipe\033[0m" >&2
         ./cook.sh "$recipe" prepare
     else
-        TIME_SOURCE="$(find recipes/$recipe/source -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
-        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
+        TIME_SOURCE="$($FIND recipes/$recipe/source -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
+        TIME_BUILD="$($FIND recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
         if [ "$TIME_SOURCE" -gt "$TIME_BUILD" ]
         then
             echo -e "\033[01;38;5;155mrepo - repreparing $recipe\033[0m" >&2
@@ -38,9 +38,9 @@ do
         echo -e "\033[01;38;5;155mrepo - building $recipe\033[0m" >&2
         ./cook.sh "$recipe" update build stage tar
     else
-        TIME_BUILD="$(find recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
-        TIME_STAGE="$(stat -c "%Y" recipes/$recipe/stage.tar.gz)"
-        TIME_RECIPE="$(find recipes/$recipe/{recipe.sh,*.patch} -printf '%Ts\n' | sort -nr | head -n 1)"
+        TIME_BUILD="$($FIND recipes/$recipe/build -type f -not -path '*/.git*' -printf "%Ts\n" | sort -nr | head -n 1)"
+        TIME_STAGE="$($STAT -c "%Y" recipes/$recipe/stage.tar.gz)"
+        TIME_RECIPE="$($FIND recipes/$recipe/{recipe.sh,*.patch} -printf '%Ts\n' | sort -nr | head -n 1)"
         if [ "$TIME_BUILD" -gt "$TIME_STAGE" -o "$TIME_RECIPE" -gt "$TIME_STAGE" ]
         then
             echo -e "\033[01;38;5;155mrepo - rebuilding $recipe\033[0m" >&2


### PR DESCRIPTION
The cookbook scripts assume they have GNU utilities 
available this causes problems in macOS which has an
BSD userland. With these changes we will use the GNU
`find` and `stat` installed by the now modified boostrap
script on https://github.com/redox-os/redox/pull/995.

**Details**

- Using `find` from Homebrew/MacPorts `findutils` package on macOS.
- Using `stat` from Homebrew/MacPorts `coreutils` package on macOS.

**Dependencies**

https://github.com/redox-os/redox/pull/995.