### PR TITLE
Enable 'backtrace' feature in libstd, to allow backtraces

### DIFF
--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,5 +1,5 @@
 [dependencies.std]
-features = ["panic_unwind"]
+features = ["panic_unwind", "backtrace"]
 
 #[dependencies.test]
 #stage = 1


### PR DESCRIPTION
Depends on https://github.com/rust-lang/rust/pull/43635 (without which this will presumably break builds).