### PR TITLE
Add symlinks to uutils package

### DIFF
--- a/recipes/uutils/recipe.sh
+++ b/recipes/uutils/recipe.sh
@@ -1,2 +1,12 @@
 GIT=https://github.com/redox-os/uutils.git
 CARGOFLAGS="--no-default-features --features redox"
+
+function recipe_stage {
+    mkdir -p "$1/bin"
+    ln -s uutils "$1/bin/chmod"
+    ln -s uutils "$1/bin/env"
+    ln -s uutils "$1/bin/expr"
+    ln -s uutils "$1/bin/install"
+    ln -s uutils "$1/bin/ls"
+    ln -s uutils "$1/bin/mktemp"
+}


### PR DESCRIPTION
Not in our coreutils:
- expr
- install
- mktemp

Replaces version in our coreutils (I'll send a PR to remove them)
- chmod—support format like `+x`
- env—in addition to printing the environment, can run a command with an environment
- ls—several features, what I needed was sorting (by time)