### PR TITLE
Fix ncurses failing to compile.

### DIFF
--- a/recipes/ncurses/recipe.sh
+++ b/recipes/ncurses/recipe.sh
@@ -12,6 +12,7 @@ function recipe_update {
 }
 
 function recipe_build {
+    export CPPFLAGS="-P"
     ./configure --host=${HOST} --prefix=""
     make
     skip=1


### PR DESCRIPTION
This PR fixes #70, by exporting a CPPFLAG variable that is required for compilation.
Apparently, it's a common issue with compiling `ncurses`: https://trac.sagemath.org/ticket/19762.