### PR TITLE
Add ffmpeg recipe

### DIFF
--- a/recipes/ffmpeg/ffmpeg.patch
+++ b/recipes/ffmpeg/ffmpeg.patch
@@ -1,0 +1,26 @@
+diff --git a/configure b/configure
+index 7201941..e3b2875 100755
+--- a/configure
++++ b/configure
+@@ -5055,6 +5055,8 @@ case $target_os in
+         ;;
+     minix)
+         ;;
++    redox)
++        ;;
+     none)
+         ;;
+     *)
+diff --git a/ffmpeg.c b/ffmpeg.c
+index 888d19a..aeeb0e5 100644
+--- a/ffmpeg.c
++++ b/ffmpeg.c
+@@ -91,7 +91,7 @@
+ 
+ #if HAVE_TERMIOS_H
+ #include <fcntl.h>
+-#include <sys/ioctl.h>
++//#include <sys/ioctl.h>
+ #include <sys/time.h>
+ #include <termios.h>
+ #elif HAVE_KBHIT

--- a/recipes/ffmpeg/recipe.sh
+++ b/recipes/ffmpeg/recipe.sh
@@ -1,0 +1,39 @@
+GIT=https://github.com/FFmpeg/FFmpeg
+
+function recipe_update {
+    echo "skipping update"
+    skip=1
+}
+
+function recipe_build {
+    ./configure \
+        --enable-cross-compile \
+        --target-os=redox \
+        --arch=x86_64 \
+        --cross_prefix=x86_64-unknown-redox- \
+        --prefix=/ \
+        --disable-doc \
+        --disable-network \
+        --disable-ffplay \
+        --disable-ffprobe \
+        --disable-ffserver
+    make
+    skip=1
+}
+
+function recipe_test {
+    echo "skipping test"
+    skip=1
+}
+
+function recipe_clean {
+    make clean
+    skip=1
+}
+
+function recipe_stage {
+    dest="$(realpath $1)"
+    make DESTDIR="$dest" install
+    rm -rf "$1"/{include,lib,share}
+    skip=1
+}


### PR DESCRIPTION
It seems to work but it has some yet unsolved issues:

* Complains about `unimplemented: select()` when running. Those messages can be dismissed by pressing the return key.
* Network support had to be disabled due to some missing symbols (`getsockopt`, `SO_REUSEADDR`, `SO_ERROR`)

Audio decoding can be tested the following way:

```
$ ffmpeg -i /tmp/softwares_salvation.webm -ar 44100 -vn -acodec pcm_s16le -f s16le temp.raw
$ sudo dd if=temp.raw of=audio: bs=16384 count=-1
```

