### PR TITLE
Add dependency info to packages

### DIFF
--- a/cook.sh
+++ b/cook.sh
@@ -260,6 +260,18 @@ function op {
             echo "name = \"$1\"" > "stage.toml"
             echo "version = \"$(op $1 version)\"" >> "stage.toml"
             echo "target = \"$TARGET\"" >> "stage.toml"
+
+            # Add runtime dependencies to package if they exist
+            if [ -n "$DEPENDS" ]
+            then
+                # Remove leading and trailing whitespace, replace whitespace between
+                # package names with commas, and surround package names with quotes
+                dependencies=$(echo -e "$DEPENDS" | sed -E 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[[:space:]]+/,/g;s/[^, ][^, ]*/"&"/g')
+                echo "depends = [$dependencies]" >> "stage.toml"
+			else
+				echo "depends = []" >> "stage.toml"
+            fi
+
             mkdir -p stage/pkg
             cp -v stage.toml "stage/pkg/$1.toml"
             pkg --target=$TARGET create stage

--- a/recipes/curl/recipe.sh
+++ b/recipes/curl/recipe.sh
@@ -1,6 +1,7 @@
 TAR=https://curl.haxx.se/download/curl-7.55.1.tar.gz
 BRANCH=redox
 BUILD_DEPENDS=(openssl)
+DEPENDS="ca-certificates"
 
 function recipe_version {
     printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"

--- a/recipes/gcc/recipe.sh
+++ b/recipes/gcc/recipe.sh
@@ -1,5 +1,6 @@
 GIT=https://github.com/redox-os/gcc.git
 BRANCH=redox
+DEPENDS="gnu-binutils newlib"
 
 export AR="${HOST}-ar"
 export AS="${HOST}-as"

--- a/recipes/rust/recipe.sh
+++ b/recipes/rust/recipe.sh
@@ -1,5 +1,6 @@
 GIT=https://github.com/ids1024/rust.git
 BRANCH=compile-redox
+DEPENDS="gcc cargo"
 
 LLVM_PREFIX=$PWD/build/llvm-root
 SYSROOT=/usr/$HOST


### PR DESCRIPTION
A variable called DEPENDS in recipes contains the runtime dependency information for packages. These get added to the package during tarring.