### PR TITLE
Add documentation for Gentoo Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,45 +25,60 @@ sudo apt install x86-64-unknown-redox-gcc
 
 ### Arch Linux
 To install the toolchain, run the following commands:
- ```bash 
+ ```bash
  # Clone libc
  git clone --recursive git@github.com:redox-os/libc
- 
- # Go to the packages 
+
+ # Go to the packages
  cd libc/packages/arch
- 
+
  # Start with binutils
  cd binutils
  makepkg -si
- 
+
  # Then autoconf
  cd ../autoconf
  makepkg -si
- 
+
  # Then gcc-freestanding
  cd ../gcc-freestanding
  makepkg -si
- 
+
  # Then newlib
  cd ../newlib
  makepkg -si
- 
+
  # Finally gcc
  cd ../gcc
  makepkg -si
  ```
 
-### Other distros/Mac OS X
-To install the toolchain, run the following commands:
- ```bash 
+### Gentoo Linux
+```bash
  # Clone libc
  git clone --recursive git@github.com:redox-os/libc
- 
+
+ # Install needed tools
+ emerge -a =sys-devel/autoconf-2.64 =sys-devel/automake-1.11.6-r2
+
+ # Run the setup script
+ cd libc
+ PREFIX=<your preferred toolchain prefix> ./setup.sh all
+
+ # Add the tools to your path
+ export PATH=$PATH:<toolchain prefix>/bin
+```
+
+### Other distros/Mac OS X
+To install the toolchain, run the following commands:
+ ```bash
+ # Clone libc
+ git clone --recursive git@github.com:redox-os/libc
+
  # Run the setup script
  cd libc
  ./setup.sh all
- 
+
  # Add the tools to your path
  export PATH=$PATH:/path/to/libc/build/prefix/bin
  ```
- 


### PR DESCRIPTION
 - whitespace cleanup
 - add gentoo docs (note: the `PREFIX` stuff is dependent on redox-os/libc#42)