### PR TITLE
vttest: Add recipe version

### DIFF
--- a/recipes/vttest/recipe.sh
+++ b/recipes/vttest/recipe.sh
@@ -1,4 +1,10 @@
+VERSION=20140305
 TAR=http://invisible-island.net/datafiles/release/vttest.tar.gz
+
+function recipe_version {
+    echo "$VERSION"
+    skip=1
+}
 
 function recipe_update {
     echo "skipping update"


### PR DESCRIPTION
Using the last patch date as the version number because of the current maintainer states the following on his [website](http://invisible-island.net/vttest/): 
> I changed the version number to 2.0 in the initial release, in 1996, and went up to 2.7 shortly after. Since then, the patch-date is the effective version number.