### PR TITLE
Fix misc problems with the xz recipe causing redox build failures

### DIFF
--- a/recipes/xz/recipe.sh
+++ b/recipes/xz/recipe.sh
@@ -1,5 +1,5 @@
 VERSION=5.2.3
-TAR=https://codeload.github.com/xz-mirror/xz/archive/v$VERSION.tar.gz
+TAR=https://github.com/xz-mirror/xz/archive/v$VERSION.tar.gz
 
 function recipe_version {
     echo "$VERSION"

--- a/recipes/xz/recipe.sh
+++ b/recipes/xz/recipe.sh
@@ -13,6 +13,7 @@ function recipe_update {
 
 function recipe_build {
     wget -O build-aux/config.sub http://git.savannah.gnu.org/cgit/config.git/plain/config.sub
+    ./autogen.sh
     ./configure --host=${HOST} --prefix=/ --enable-threads=no
     make
     skip=1


### PR DESCRIPTION
Hi.

I hit these when trying a clean build using the instructions [_here_](https://github.com/redox-os/redox#-manual-setup-).

Here's an excerpt from the build log:

```
Create directory build/filesystem/
repo - coreutils up to date
repo - drivers up to date
repo - preparing extrautils
cook - extrautils prepare
~/work/repos/redox/redox/cookbook ~/work/repos/redox/redox/cookbook/recipes/extrautils
./repo.sh: line 38: [: : integer expression expected
repo - building xz
cook - xz build
build-aux/config.sub: No such file or directory
./repo.sh failed.make: *** [mk/filesystem.mk:12: build/filesystem.bin] Error 1

```
The failure is misleading and after a bit of digging it turns out to be because the xz tarball couldn't be fetched. A follow-on problem was to do with invoking configure which requires generation first.

The 2 commits in this PR fixed the problems for me.

Please consider and apply if appropriate.

Thanks.