### PR TITLE
Add TiMidity++ and GeneralUser GS

### DIFF
--- a/recipes/generaluser-gs/recipe.sh
+++ b/recipes/generaluser-gs/recipe.sh
@@ -1,0 +1,33 @@
+VERSION=1.471
+GIT=https://github.com/xTibor/redox-generaluser-gs.git
+
+function recipe_version {
+    echo "$VERSION"
+    skip=1
+}
+
+function recipe_update {
+    echo "skipping update"
+    skip=1
+}
+
+function recipe_build {
+    echo "skipping build"
+    skip=1
+}
+
+function recipe_test {
+    echo "skipping test"
+    skip=1
+}
+
+function recipe_clean {
+    echo "skipping clean"
+    skip=1
+}
+
+function recipe_stage {
+    mkdir -pv "$1/share/generaluser-gs"
+    cp -Rv ./* "$1/share/generaluser-gs"
+    skip=1
+}

--- a/recipes/timidity/recipe.sh
+++ b/recipes/timidity/recipe.sh
@@ -1,0 +1,42 @@
+VERSION=2.14.0
+GIT=https://github.com/xTibor/redox-timidity.git
+BRANCH=redox
+DEPENDS="generaluser-gs"
+
+function recipe_version {
+    echo "$VERSION"
+    skip=1
+}
+
+function recipe_update {
+    echo "skipping update"
+    skip=1
+}
+
+function recipe_build {
+    autoreconf -f -i
+    wget -O autoconf/config.sub http://git.savannah.gnu.org/cgit/config.git/plain/config.sub
+    ./configure --host=${HOST} --prefix=''
+    make
+    skip=1
+}
+
+function recipe_test {
+    echo "skipping test"
+    skip=1
+}
+
+function recipe_clean {
+    make clean
+    skip=1
+}
+
+function recipe_stage {
+    dest="$(realpath $1)"
+    make DESTDIR="$dest" install
+
+    mkdir -pv "$1/share/timidity"
+    echo "soundfont /share/generaluser-gs/generaluser-gs.sf2" >> "$1/share/timidity/timidity.cfg"
+
+    skip=1
+}


### PR DESCRIPTION
This PR adds recipes for two new packages, `generaluser-gs` and `timidity`. GeneralUser GS has [a custom license](https://github.com/xTibor/redox-generaluser-gs/blob/master/LICENSE.txt) but it's free, permissive and encourages redistribution.

## Testing
Copypasta for quick testing:
```
sudo pkg install generaluser-gs timidity
```
```
wget -O test.mid https://github.com/ShinkoNet/shinkonet.github.io/raw/master/MIDIArchive/IshukanCommunication.mid
```
```
sudo timidity -OR test.mid
```