### PR TITLE
Add ca-certificates dependency for git

### DIFF
--- a/recipes/git/recipe.sh
+++ b/recipes/git/recipe.sh
@@ -1,6 +1,7 @@
 VERSION=2.13.1
 TAR=https://www.kernel.org/pub/software/scm/git/git-$VERSION.tar.xz
 BUILD_DEPENDS=(zlib curl openssl expat)
+DEPENDS="ca-certificates"
 
 export AR="${HOST}-ar"
 export AS="${HOST}-as"


### PR DESCRIPTION
Git requires this package to be able to work over HTTPS.