### PR TITLE
Add ncursesw recipe, terminfo changes

### DIFF
--- a/recipes/ncursesw/01-config-sub.patch
+++ b/recipes/ncursesw/01-config-sub.patch
@@ -1,0 +1,21 @@
+diff -ru source/config.sub source-new/config.sub
+--- source/config.sub	2015-05-02 13:52:04.000000000 +0200
++++ source-new/config.sub	2017-08-13 13:12:16.485670615 +0200
+@@ -2,7 +2,7 @@
+ # Configuration validation subroutine script.
+ #   Copyright 1992-2015 Free Software Foundation, Inc.
+ 
+-timestamp='2015-03-08'
++timestamp='2017-08-13'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -1371,7 +1371,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST END IN A *, to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* | -redox* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \

--- a/recipes/ncursesw/recipe.sh
+++ b/recipes/ncursesw/recipe.sh
@@ -14,7 +14,7 @@ function recipe_update {
 
 function recipe_build {
     export CPPFLAGS="-P"
-    ./configure --host=${HOST} --prefix="" --disable-db-install
+    ./configure --host=${HOST} --prefix="" --enable-widec --disable-db-install
     make
     skip=1
 }

--- a/recipes/terminfo/recipe.sh
+++ b/recipes/terminfo/recipe.sh
@@ -21,12 +21,12 @@ function recipe_test {
 }
 
 function recipe_clean {
-    echo "skipping clean" 
+    echo "skipping clean"
     skip=1
 }
 
 function recipe_stage {
-    mkdir -p ../stage/share/terminfo
-    cp -r  * ../stage/share/terminfo/
+    mkdir -p ../stage/share
+    cp -r  * ../stage/share/
     skip=1
 }

--- a/recipes/vim/recipe.sh
+++ b/recipes/vim/recipe.sh
@@ -1,6 +1,7 @@
 VERSION=8.0.586
 TAR=http://ftp.vim.org/vim/unix/vim-$VERSION.tar.bz2
 BUILD_DEPENDS=(ncurses)
+DEPENDS="terminfo"
 
 export AR="${HOST}-ar"
 export AS="${HOST}-as"
@@ -35,7 +36,7 @@ function recipe_build {
     export vim_cv_stat_ignores_slash=no
     export vim_cv_memmove_handles_overlap=yes
     ./configure --host=${HOST} --prefix=/ --with-tlib=ncurses
-    make 
+    make
     skip=1
 }
 


### PR DESCRIPTION
This PR introduces the following changes:
* Adds a new `ncursesw` package. It enables ncurses apps that require UTF-8 support to build.
* Removes the `terminfo` related files from the `ncurses` package. They are unnecessary there after the introduction of the `terminfo` package. They could also cause some clash between the `ncurses` and `ncursesw` packages.
* The `tabset` files has been added to the `terminfo` package and it required some path changes to the `terminfo` recipe.
* Added `terminfo` runtime deps where I think it's required.