### PR TITLE
Link whoami to id; Depends redox-os/userutils/#32

### DIFF
--- a/recipes/userutils/recipe.sh
+++ b/recipes/userutils/recipe.sh
@@ -2,4 +2,6 @@ GIT=https://github.com/redox-os/userutils.git
 
 function recipe_stage {
     cp -Rv res "$1/etc"
+    mkdir -p "$1/bin"
+    ln -s id "$1/bin/whoami"
 }


### PR DESCRIPTION
Alright, this should re-implement `whoami` as a link to id, depending on  redox-os/userutils/pull/32