### PR TITLE
netsurf: Fix HTML forms

### DIFF
--- a/recipes/netsurf/01_redox.patch
+++ b/recipes/netsurf/01_redox.patch
@@ -1,6 +1,6 @@
 diff -rupNw source-original/libnsfb/Makefile source/libnsfb/Makefile
 --- source-original/libnsfb/Makefile	2017-10-16 12:09:35.000000000 +0200
-+++ source/libnsfb/Makefile	2018-02-28 15:55:23.835716012 +0100
++++ source/libnsfb/Makefile	2018-03-04 20:43:18.172956846 +0100
 @@ -43,10 +43,10 @@ endif
  NSFB_XCB_PKG_NAMES := xcb xcb-icccm xcb-image xcb-keysyms xcb-atom
  
@@ -17,7 +17,7 @@ diff -rupNw source-original/libnsfb/Makefile source/libnsfb/Makefile
  NSFB_ABLE_AVAILABLE := no
 diff -rupNw source-original/libnsfb/src/plot/32bpp-xbgr8888.c source/libnsfb/src/plot/32bpp-xbgr8888.c
 --- source-original/libnsfb/src/plot/32bpp-xbgr8888.c	2017-10-16 12:09:35.000000000 +0200
-+++ source/libnsfb/src/plot/32bpp-xbgr8888.c	2018-02-28 15:55:23.847716494 +0100
++++ source/libnsfb/src/plot/32bpp-xbgr8888.c	2018-03-04 20:43:18.188956997 +0100
 @@ -52,7 +52,7 @@ static inline nsfb_colour_t pixel_to_col
   */
  static inline uint32_t colour_to_pixel(UNUSED nsfb_t *nsfb, nsfb_colour_t c)
@@ -38,7 +38,7 @@ diff -rupNw source-original/libnsfb/src/plot/32bpp-xbgr8888.c source/libnsfb/src
  #endif
 diff -rupNw source-original/libnsfb/src/plot/32bpp-xrgb8888.c source/libnsfb/src/plot/32bpp-xrgb8888.c
 --- source-original/libnsfb/src/plot/32bpp-xrgb8888.c	2017-10-16 12:09:35.000000000 +0200
-+++ source/libnsfb/src/plot/32bpp-xrgb8888.c	2018-02-28 15:55:23.847716494 +0100
++++ source/libnsfb/src/plot/32bpp-xrgb8888.c	2018-03-04 20:43:18.188956997 +0100
 @@ -52,7 +52,7 @@ static inline nsfb_colour_t pixel_to_col
   */
  static inline uint32_t colour_to_pixel(UNUSED nsfb_t *nsfb, nsfb_colour_t c)
@@ -59,7 +59,7 @@ diff -rupNw source-original/libnsfb/src/plot/32bpp-xrgb8888.c source/libnsfb/src
  #endif
 diff -rupNw source-original/libnsfb/src/plot.h source/libnsfb/src/plot.h
 --- source-original/libnsfb/src/plot.h	2017-10-16 12:09:35.000000000 +0200
-+++ source/libnsfb/src/plot.h	2018-02-28 15:55:23.847716494 +0100
++++ source/libnsfb/src/plot.h	2018-03-04 20:43:18.188956997 +0100
 @@ -36,7 +36,7 @@
          #define NSFB_BE_BYTE_ORDER
      #endif
@@ -71,7 +71,7 @@ diff -rupNw source-original/libnsfb/src/plot.h source/libnsfb/src/plot.h
              #define NSFB_BE_BYTE_ORDER
 diff -rupNw source-original/libnsfb/src/surface/sdl.c source/libnsfb/src/surface/sdl.c
 --- source-original/libnsfb/src/surface/sdl.c	2017-10-16 12:09:35.000000000 +0200
-+++ source/libnsfb/src/surface/sdl.c	2018-02-28 15:55:23.847716494 +0100
++++ source/libnsfb/src/surface/sdl.c	2018-03-04 20:43:18.188956997 +0100
 @@ -458,7 +458,7 @@ static int sdl_initialise(nsfb_t *nsfb)
          return -1;
  
@@ -123,7 +123,7 @@ diff -rupNw source-original/libnsfb/src/surface/sdl.c source/libnsfb/src/surface
      if (got_event == 0) {
 diff -rupNw source-original/libparserutils/src/input/filter.c source/libparserutils/src/input/filter.c
 --- source-original/libparserutils/src/input/filter.c	2017-10-16 12:09:36.000000000 +0200
-+++ source/libparserutils/src/input/filter.c	2018-02-28 15:55:23.847716494 +0100
++++ source/libparserutils/src/input/filter.c	2018-03-04 20:43:18.188956997 +0100
 @@ -10,7 +10,7 @@
  #include <stdlib.h>
  #include <string.h>
@@ -207,7 +207,7 @@ diff -rupNw source-original/libparserutils/src/input/filter.c source/libparserut
  		input->cd = (iconv_t) -1;
 diff -rupNw source-original/netsurf/content/fetchers/file.c source/netsurf/content/fetchers/file.c
 --- source-original/netsurf/content/fetchers/file.c	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/content/fetchers/file.c	2018-02-28 15:55:23.851716655 +0100
++++ source/netsurf/content/fetchers/file.c	2018-03-04 20:43:18.216957262 +0100
 @@ -39,7 +39,7 @@
  #include <time.h>
  #include <stdio.h>
@@ -228,7 +228,7 @@ diff -rupNw source-original/netsurf/content/fetchers/file.c source/netsurf/conte
  	size_t buf_size;
 diff -rupNw source-original/netsurf/content/urldb.c source/netsurf/content/urldb.c
 --- source-original/netsurf/content/urldb.c	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/content/urldb.c	2018-02-28 15:55:23.851716655 +0100
++++ source/netsurf/content/urldb.c	2018-03-04 20:43:18.216957262 +0100
 @@ -630,7 +630,7 @@ static bool urldb__host_is_ip_address(co
  	size_t host_len = strlen(host);
  	const char *sane_host;
@@ -249,7 +249,7 @@ diff -rupNw source-original/netsurf/content/urldb.c source/netsurf/content/urldb
  	    (sane_host[host_len - 1] != ']')) {
 diff -rupNw source-original/netsurf/frontends/framebuffer/Makefile source/netsurf/frontends/framebuffer/Makefile
 --- source-original/netsurf/frontends/framebuffer/Makefile	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/frontends/framebuffer/Makefile	2018-02-28 16:43:21.098712544 +0100
++++ source/netsurf/frontends/framebuffer/Makefile	2018-03-04 20:43:18.232957414 +0100
 @@ -35,8 +35,8 @@ LDFLAGS += -Wl,--no-whole-archive
  
  # freetype is optional but does not use pkg-config
@@ -263,7 +263,7 @@ diff -rupNw source-original/netsurf/frontends/framebuffer/Makefile source/netsur
  
 diff -rupNw source-original/netsurf/Makefile.config source/netsurf/Makefile.config
 --- source-original/netsurf/Makefile.config	1970-01-01 01:00:00.000000000 +0100
-+++ source/netsurf/Makefile.config	2018-02-28 18:12:51.362698183 +0100
++++ source/netsurf/Makefile.config	2018-03-04 20:43:18.244957528 +0100
 @@ -0,0 +1,27 @@
 +override NETSURF_HOMEPAGE := "https://www.redox-os.org/"
 +override NETSURF_FB_FRONTEND := sdl
@@ -292,9 +292,39 @@ diff -rupNw source-original/netsurf/Makefile.config source/netsurf/Makefile.conf
 +override NETSURF_FB_FONT_MONOSPACE_BOLD := Mono/Fira/Bold.ttf
 +override NETSURF_FB_FONT_CURSIVE := Sans/Fira/Regular.ttf
 +override NETSURF_FB_FONT_FANTASY := Sans/Fira/Regular.ttf
+diff -rupNw source-original/netsurf/render/form.c source/netsurf/render/form.c
+--- source-original/netsurf/render/form.c	2017-10-16 12:09:36.000000000 +0200
++++ source/netsurf/render/form.c	2018-03-09 00:03:07.456378705 +0100
+@@ -1080,7 +1080,7 @@ char *form_encode_item(const char *item,
+ 	if (!item || !charset)
+ 		return NULL;
+ 
+-	snprintf(cset, sizeof cset, "%s//TRANSLIT", charset);
++	snprintf(cset, sizeof cset, "%s", charset);
+ 
+ 	err = utf8_to_enc(item, cset, 0, &ret);
+ 	if (err == NSERROR_BAD_ENCODING) {
+@@ -1092,7 +1092,7 @@ char *form_encode_item(const char *item,
+ 			/* nope, try fallback charset (if any) */
+ 			if (fallback) {
+ 				snprintf(cset, sizeof cset, 
+-						"%s//TRANSLIT", fallback);
++						"%s", fallback);
+ 				err = utf8_to_enc(item, cset, 0, &ret);
+ 
+ 				if (err == NSERROR_BAD_ENCODING) {
+@@ -1105,7 +1105,7 @@ char *form_encode_item(const char *item,
+ 
+ 			if (err == NSERROR_BAD_ENCODING) {
+ 				/* that also failed, use 8859-1 */
+-				err = utf8_to_enc(item, "ISO-8859-1//TRANSLIT",
++				err = utf8_to_enc(item, "ISO-8859-1",
+ 						0, &ret);
+ 				if (err == NSERROR_BAD_ENCODING) {
+ 					/* and without transliteration */
 diff -rupNw source-original/netsurf/utils/log.c source/netsurf/utils/log.c
 --- source-original/netsurf/utils/log.c	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/utils/log.c	2018-02-28 15:55:23.855716815 +0100
++++ source/netsurf/utils/log.c	2018-03-04 20:43:18.252957604 +0100
 @@ -261,18 +261,18 @@ nserror nslog_init(nslog_ensure_t *ensur
  	/* sucessfull logging initialisation so log system info */
  	if (ret == NSERROR_OK) {
@@ -326,7 +356,7 @@ diff -rupNw source-original/netsurf/utils/log.c source/netsurf/utils/log.c
  	return ret;
 diff -rupNw source-original/netsurf/utils/useragent.c source/netsurf/utils/useragent.c
 --- source-original/netsurf/utils/useragent.c	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/utils/useragent.c	2018-02-28 15:55:23.855716815 +0100
++++ source/netsurf/utils/useragent.c	2018-03-04 20:43:18.252957604 +0100
 @@ -44,9 +44,9 @@ user_agent_build_string(void)
          char *ua_string;
          int len;
@@ -342,7 +372,7 @@ diff -rupNw source-original/netsurf/utils/useragent.c source/netsurf/utils/usera
                         netsurf_version_major,
 diff -rupNw source-original/netsurf/utils/utsname.h source/netsurf/utils/utsname.h
 --- source-original/netsurf/utils/utsname.h	2017-10-16 12:09:36.000000000 +0200
-+++ source/netsurf/utils/utsname.h	2018-02-28 15:55:23.855716815 +0100
++++ source/netsurf/utils/utsname.h	2018-03-04 20:43:18.252957604 +0100
 @@ -24,7 +24,7 @@
  #ifndef _NETSURF_UTILS_UTSNAME_H_
  #define _NETSURF_UTILS_UTSNAME_H_


### PR DESCRIPTION
The //TRANSLIT iconv extension doesn't seem to be supported by newlib.

Some good news: NetSurf is now able to log into GitHub and open pull requests. Like this one.