### PR TITLE
Move from xargo to cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ stage.tar
 stage.tar.gz
 stage.toml
 sysroot
-xargo
+cargo

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.std]
-features = ["panic_unwind", "backtrace"]
-
-#[dependencies.test]
-#stage = 1
-

--- a/clean.sh
+++ b/clean.sh
@@ -15,4 +15,4 @@ do
     ./cook.sh "$recipe" distclean
 done
 
-rm -rf xargo
+rm -rf cargo

--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,7 @@ HOST=$TARGET
 ROOT="$(cd `dirname "$0"` && pwd)"
 REPO="$ROOT/repo/$TARGET"
 export PATH="${ROOT}/bin:$PATH"
-export XARGO_HOME="${ROOT}/xargo"
+export CARGO_HOME="${ROOT}/cargo"
 
 export AR="${HOST}-ar"
 export AS="${HOST}-as"

--- a/cook.sh
+++ b/cook.sh
@@ -222,7 +222,7 @@ function op {
             fi
             if [ "$skip" -eq "0" ]
             then
-                xargo update
+                cargo update
             fi
             popd > /dev/null
             ;;
@@ -299,8 +299,7 @@ function op {
 
             if [ "$skip" -eq "0" ]
             then
-                cp -p "$ROOT/Xargo.toml" "Xargo.toml"
-                xargo build --target "$TARGET" $release_flag $CARGOFLAGS
+                cargo build --target "$TARGET" $release_flag $CARGOFLAGS
             fi
             popd > /dev/null
             ;;
@@ -320,8 +319,7 @@ function op {
 
             if [ "$skip" -eq "0" ]
             then
-                cp -p "$ROOT/Xargo.toml" "Xargo.toml"
-                xargo test --no-run --target "$TARGET" $release_flag $CARGOFLAGS
+                cargo test --no-run --target "$TARGET" $release_flag $CARGOFLAGS
             fi
             popd > /dev/null
             ;;
@@ -334,7 +332,7 @@ function op {
             fi
             if [ "$skip" -eq "0" ]
             then
-                xargo clean
+                cargo clean
             fi
             popd > /dev/null
             ;;

--- a/setup.sh
+++ b/setup.sh
@@ -16,10 +16,10 @@ then
     echo "Installing cargo-config"
     cargo install -f cargo-config
 fi
-if [ -z "$(which xargo)" ]
+if [ -z "$(which cargo)" ]
 then
-    echo "Installing xargo"
-    cargo install -f xargo
+    echo "Must install cargo"
+    exit 1
 fi
 
 echo "cook.sh is ready to use"


### PR DESCRIPTION
xargo is deprecated. Use cargo instead of xargo now. I removed the `Xargo.toml` and built redox and everything seems to be working. Is removing the `Xargo.toml` the right path? Do we need to add anything to the `Cargo.toml`?