### PR TITLE
sdl: Revert unicode fix

### DIFF
--- a/recipes/sdl/01_orbital.patch
+++ b/recipes/sdl/01_orbital.patch
@@ -69,7 +69,7 @@ diff -rupNw source-original/include/SDL_config.h.in source/include/SDL_config.h.
 diff -rupNw source-original/src/video/orbital/SDL_orbitalevents.c source/src/video/orbital/SDL_orbitalevents.c
 --- source-original/src/video/orbital/SDL_orbitalevents.c	1970-01-01 01:00:00.000000000 +0100
 +++ source/src/video/orbital/SDL_orbitalevents.c	2018-05-01 17:31:52.770229654 +0200
-@@ -0,0 +1,198 @@
+@@ -0,0 +1,197 @@
 +/*
 +    SDL - Simple DirectMedia Layer
 +    Copyright (C) 1997-2012 Sam Lantinga
@@ -110,7 +110,6 @@ diff -rupNw source-original/src/video/orbital/SDL_orbitalevents.c source/src/vid
 +static bool last_button_middle = false;
 +static bool last_button_right = false;
 +
-+// TODO: Find out why NetSurf recieves NULL chars when the keysym.unicode field is used
 +void ORBITAL_PumpEvents(_THIS)
 +{
 +    SDL_keysym keysym;
@@ -121,7 +120,7 @@ diff -rupNw source-original/src/video/orbital/SDL_orbitalevents.c source/src/vid
 +    while (oeo.tag != OrbEventOption_None) {
 +        switch (oeo.tag) {
 +            case OrbEventOption_Key:
-+                //keysym.unicode = oeo.key.character;
++                keysym.unicode = oeo.key.character;
 +                keysym.scancode = oeo.key.scancode;
 +                keysym.sym = keymap[oeo.key.scancode];
 +                keysym.mod = KMOD_NONE;


### PR DESCRIPTION
This PR fixes the keyboard input in OpenTTD (alphanumerical keys didn't work). The NetSurf bug that was the reason I uncommented that line is also no longer reproducible.